### PR TITLE
Use port 8080 instead of port 5000

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Follow along [here](https://docs.osohq.com/node/getting-started/quickstart.html)
 ## Make some changes
 
 If you visit
-[http://localhost:5000/repo/gmail](http://localhost:5000/repo/gmail), you
+[http://localhost:8080/repo/gmail](http://localhost:8080/repo/gmail), you
 should get a 200 response. If you visit
-[http://localhost:5000/repo/react](http://localhost:5000/repo/react), you
+[http://localhost:8080/repo/react](http://localhost:8080/repo/react), you
 should see a 404.
 
 Add this code to `main.polar`:
@@ -23,6 +23,6 @@ has_permission(_user: User, "read", repository: Repository) if
 ```
 
 Now, when you visit
-[http://localhost:5000/repo/react](http://localhost:5000/repo/react), you should
+[http://localhost:8080/repo/react](http://localhost:8080/repo/react), you should
 see a proper 200 response, because the `react` repository is marked as public
 in `models.js`.

--- a/server.js
+++ b/server.js
@@ -27,7 +27,7 @@ async function start() {
       }
     }
   });
-  app.listen(5000, () => console.log("Server running on port 5000"));
+  app.listen(8080, () => console.log("Server running on port 8080"));
 }
 
 start();


### PR DESCRIPTION
This PR changes the port used by the express server from 5000 to 8080 to avoid "address already in use" error. [The quickstart docs](https://docs.osohq.com/node/getting-started/quickstart.html#1-clone-the-repo-and-install-dependencies) should be updated to reflect this, but I'm not sure where they are.

This is what I saw previously (MacOS v12.3.1):

```bash
➜  oso-nodejs-quickstart git:(main) npm start

> quickstart@0.0.0 start
> node server.js

node:events:504
      throw er; // Unhandled 'error' event
      ^

Error: listen EADDRINUSE: address already in use :::5000
```

Apple recently decided to [use port 5000 for 'new AirPlay functionality'](https://developer.apple.com/forums/thread/682332), so anyone who tries to run the quickstart on the latest version of MacOS will likely see this error.

Why change to port 8080 in particular? No reason, this is just [the port Svelte changed to](https://github.com/sveltejs/template/pull/278) when addressing the same issue in their CLI.